### PR TITLE
Update 04_task_file.py

### DIFF
--- a/Module6/practice/files/04_task_file.py
+++ b/Module6/practice/files/04_task_file.py
@@ -9,3 +9,17 @@
 # Подсказка:
 # Чтобы получить список больших букв русского алфавита:
 # print(list(map(chr, range(ord('А'), ord('Я')+1))))
+
+first_symb_fruits = {}                                                    # формирование словаря с ключами от "А" до "Я"
+for symb in list(map(chr, range(ord('А'), ord('Я') + 1))):                #
+    first_symb_fruits.update([(symb, [])])                                #
+#first_symb_fruits = dict.fromkeys(list(map(chr, range(ord('А'), ord('Я') + 1))), [])   #при таком способе создания словаря метод append работает неожиданно, надо разбираться
+with open('data/fruits.txt', encoding='utf-8') as f:
+    for line in f:
+        line = line.strip()
+        if line:
+#            first_symb.setdefault(line[0], [])   #если не обязательно делать файл с каждой буквой, данный метод позволяет обойтись без предаварительного создания словаря
+            first_symb_fruits[line[0]].append(line + '\n' + '\n')
+for symb in first_symb_fruits:
+    with open(f'data/fruits/fruits_{symb}.txt', 'w', encoding='utf-8') as f:
+        print(*(first_symb_fruits[symb]), file=f)


### PR DESCRIPTION
При создании словаря методом dict.fromkeys() в дальнейшем пополняя его методом .append для определенного ключа неожиданно срабатывает пополнение для всех ключей сразу. Непонятно. Ниже вариант для примера:

              Файл my.txt
В Hello
Г world

letters = dict.fromkeys(list(map(chr, range(ord('А'), ord('Д') + 1))), [])
print(letters)
letters_new = {'А': [], 'Б': [], 'В': [],'Г': [], 'Д': []}
print(letters_new)
with open('my.txt', encoding='utf-8') as f:
    for line in f:
        letters[line[0]].append(line)
        letters_new[line[0]].append(line)
print(letters)
print(letters_new)